### PR TITLE
hwcomposer: Cleaner solution to deal with QCOM_BSP, QTI_BSP and QCOM_…

### DIFF
--- a/hwcomposer/hwcomposer.pro
+++ b/hwcomposer/hwcomposer.pro
@@ -33,6 +33,18 @@ QT += core-private gui-private egl_support-private fontdatabase_support-private 
 DEFINES += QEGL_EXTRA_DEBUG
 CONFIG += egl qpa/genericunixfontdatabase
 
+enable-qcom-bsp {
+    DEFINES += QCOM_BSP
+}
+
+enable-qti-bsp {
+    DEFINES += QTI_BSP
+}
+
+enable-qcom-hardware {
+    DEFINES += QCOM_HARDWARE
+}
+
 CONFIG += link_pkgconfig
 
 # For linking against libQt5PlatformSupport.a


### PR DESCRIPTION
…HARWARE

This was previously done by patches that were applied. Having this as configs is a nicer way of doing it.

Removes the need of nasty hacks such as: https://github.com/webOS-ports/meta-webos-ports/blob/herrie/qt5qpa/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0002-Add-QCOM_BSP-define-switch.patch

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>